### PR TITLE
feat: support Notion database

### DIFF
--- a/src/common/backend/services/notion/service.ts
+++ b/src/common/backend/services/notion/service.ts
@@ -42,15 +42,34 @@ interface NotionUserContent {
             title: string[][];
             content: string[];
           };
+          collection_id: string;
+        };
+      };
+    };
+    collection: {
+      [uuid: string]: {
+        role: string;
+        value: {
+          id: string;
+          version: string;
+          parent_id: string;
+          name: string[][];
         };
       };
     };
   };
 }
 
+interface NotionRepository extends Repository {
+  pageType: string;
+}
+
+const PAGE = 'page';
+const COLLECTION_VIEW_PAGE = 'collection_view_page';
+
 export default class NotionDocumentService implements DocumentService {
   private request: AxiosInstance;
-  private repositories: Repository[];
+  private repositories: NotionRepository[];
   private userContent?: NotionUserContent;
 
   constructor() {
@@ -110,24 +129,47 @@ export default class NotionDocumentService implements DocumentService {
 
     const spaces = this.userContent.recordMap.space;
     const blocks = this.userContent.recordMap.block;
+    const collections = this.userContent.recordMap.collection;
+
     if (!blocks) {
       this.repositories = [];
       return [];
     }
-    const result = Object.values(blocks)
-      .filter(
-        ({ value }) => !!value.properties && !!value.properties.title && !!spaces[value.parent_id]
-      )
-      .map(
-        ({ value }): Repository => {
-          return {
-            id: value.id,
-            name: value.properties.title.toString(),
-            groupId: spaces[value.parent_id].value.domain,
-            groupName: spaces[value.parent_id].value.name,
-          };
-        }
-      );
+
+    const result: NotionRepository[] = [];
+    Object.values(blocks).forEach(({ value }) => {
+      if (
+        value.type === PAGE &&
+        !!value.properties &&
+        !!value.properties.title &&
+        !!spaces[value.parent_id]
+      ) {
+        result.push({
+          id: value.id,
+          name: value.properties.title.toString(),
+          groupId: spaces[value.parent_id].value.domain,
+          groupName: spaces[value.parent_id].value.name,
+          pageType: PAGE,
+        });
+      }
+
+      if (
+        value.type === COLLECTION_VIEW_PAGE &&
+        !!value.collection_id &&
+        !!collections[value.collection_id] &&
+        !!collections[value.collection_id].value &&
+        !!collections[value.collection_id].value.name &&
+        !!spaces[value.parent_id]
+      ) {
+        result.push({
+          id: collections[value.collection_id].value.id,
+          name: collections[value.collection_id].value.name.toString(),
+          groupId: spaces[value.parent_id].value.domain,
+          groupName: spaces[value.parent_id].value.name,
+          pageType: COLLECTION_VIEW_PAGE,
+        });
+      }
+    });
 
     this.repositories = result;
 
@@ -140,7 +182,13 @@ export default class NotionDocumentService implements DocumentService {
     content,
   }: CreateDocumentRequest): Promise<CompleteStatus> => {
     let fileName = `${title}.md`;
-    const documentId = await this.createEmptyFile(repositoryId, content);
+
+    const repository = this.repositories.find(o => o.id === repositoryId);
+    if (!repository) {
+      throw new Error('Illegal repository');
+    }
+
+    const documentId = await this.createEmptyFile(repository, content);
     const fileUrl = await this.getFileUrl(fileName);
     await axios.put(fileUrl.signedPutUrl, `${content}`, {
       headers: {
@@ -158,24 +206,23 @@ export default class NotionDocumentService implements DocumentService {
         },
       },
     });
-    const repository = this.repositories.find(o => o.id === repositoryId);
-    if (!repository) {
-      throw new Error('Illegal repository');
-    }
+
     return {
       href: `https://www.notion.so/${repository.groupId}/${documentId.replace(/-/g, '')}`,
     };
   };
 
-  createEmptyFile = async (parentId: string, title: string) => {
+  createEmptyFile = async (repository: NotionRepository, title: string) => {
     if (!this.userContent) {
       this.userContent = await this.getUserContent();
     }
     const documentId = generateUuid();
+    const parentId = repository.id;
     const userId = Object.values(this.userContent.recordMap.notion_user)[0].value.id;
     const time = new Date().getDate();
-    await this.request.post('api/v3/submitTransaction', {
-      operations: [
+    let operations;
+    if (repository.pageType === PAGE) {
+      operations = [
         {
           id: documentId,
           table: 'block',
@@ -238,7 +285,36 @@ export default class NotionDocumentService implements DocumentService {
           command: 'update',
           args: { last_edited_time: time },
         },
-      ],
+      ];
+    } else if (repository.pageType === COLLECTION_VIEW_PAGE) {
+      operations = [
+        {
+          id: documentId,
+          table: 'block',
+          path: [],
+          command: 'set',
+          args: {
+            type: 'page',
+            id: documentId,
+            version: 1,
+          },
+        },
+        {
+          id: documentId,
+          table: 'block',
+          path: [],
+          command: 'update',
+          args: {
+            parent_id: parentId,
+            parent_table: 'collection',
+            alive: true,
+          },
+        },
+      ];
+    }
+
+    await this.request.post('api/v3/submitTransaction', {
+      operations,
     });
     return documentId;
   };


### PR DESCRIPTION
Notion Page Block 分两种类型：`page` 和 `collection_view_page`，后者即 Database。
两种页面结构稍有不同，所以需要在创建子页面时稍微判断一下，用不同的字段。

page：和现在的逻辑一致，直接创建。
```typescript
{
  parent_id: pageId,
  parent_table: 'block',
  alive: true
}
```
collection_view_page：此时页面一定会关联一个 collection（即 database），所以需要做的是在这个 collection 下面创建新页面，而不是 page block 下面。
```typescript
{
  parent_id: collectionId,
  parent_table: 'collection',
  alive: true
}
```
在 Notion 自己的逻辑里，也是用以上三个字段来从数据库或缓存中存取 Database 内容的。