### PR TITLE
Add Wechat's image server uri to clipper's manifest to fix CORS issue.

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -21,6 +21,7 @@ let manifestExtra = {
     'storage',
     'https://api.clipper.website/*',
     'https://resource.clipper.website/*',
+    'https://mmbiz.qpic.cn/*',
   ],
   optional_permissions: ['cookies', '<all_urls>', 'webRequest', 'webRequestBlocking'],
 };


### PR DESCRIPTION
# 问题

剪藏微信公众号网页的时候，同步到图床，遇到 CORS 报错；但是剪藏其他网页就没有问题。

![image](https://user-images.githubusercontent.com/915546/95890799-d2655f80-0db6-11eb-977a-2b22ea7e1dd2.png)

怀疑是微信图床有更严格的 CORS 限制。

# 解决

通过 manifest.json 的 permission 里增加微信图床domain 可以解决这个问题。或者大家有没有更好的解法？

![image](https://user-images.githubusercontent.com/915546/95890915-f759d280-0db6-11eb-8185-41a9c2223362.png)
