### PR TITLE
Add wallabag support

### DIFF
--- a/src/common/backend/clients/wallabag/client.test.ts
+++ b/src/common/backend/clients/wallabag/client.test.ts
@@ -58,9 +58,17 @@ describe('test WallabagClient', () => {
       wallabag_host: 'https://wallabag_host',
     };
 
+    let isFirstRequest = true;
     const mockRequestService = new MockRequestService(url => {
       switch (url) {
         case `${inputStub.wallabag_host}/api/user.json`:
+          if (isFirstRequest) {
+            // the first request fails with status 401
+            isFirstRequest = false;
+            const err = new Error() as any;
+            err.response = { status: 401 };
+            throw err;
+          }
           return notebookListStubResponse;
         case `${inputStub.wallabag_host}/oauth/v2/token?grant_type=refresh_token&client_id=client_id&client_secret=client_secret&refresh_token=refresh_token`:
           return refreshTokenStubResponse;
@@ -76,7 +84,7 @@ describe('test WallabagClient', () => {
     expect(firstUserInfoRequest[0]).toEqual(userInfoUrl);
     expect(secondUserInfoRequest[0]).toEqual(userInfoUrl);
     expect(secondUserInfoRequest[1].headers.Authorization).toEqual(
-      `Bearer ${refreshTokenStubResponse}`
+      `Bearer ${refreshTokenStubResponse.access_token}`
     );
 
     expect(notebookListStubResponse).toEqual(result);

--- a/src/common/backend/clients/wallabag/client.test.ts
+++ b/src/common/backend/clients/wallabag/client.test.ts
@@ -1,0 +1,110 @@
+import { MockRequestService } from '@/__test__/utils';
+import WallabagClient from './client';
+const FormData = require('form-data');
+
+describe('test WallabagClient', () => {
+  test('test login', async () => {
+    const expectedResponse = {
+      access_token: 'new_access_token',
+      refresh_token: 'new_refresh_token',
+    };
+    const mockRequestService = new MockRequestService(() => expectedResponse);
+    const inputStub = {
+      access_token: 'access_token',
+      refresh_token: 'refresh_token',
+      client_id: 'client_id',
+      client_secret: 'client_secret',
+      wallabag_host: 'https://wallabag_host',
+    };
+    const client = new WallabagClient(inputStub, mockRequestService);
+    const result = await client.refreshToken();
+    const expectUrlGenerated = `${inputStub.wallabag_host}/oauth/v2/token?grant_type=refresh_token&client_id=client_id&client_secret=client_secret&refresh_token=refresh_token`;
+    expect(mockRequestService.mock.request.mock.calls[0][0]).toEqual(expectUrlGenerated);
+    expect(result).toEqual(expectedResponse.access_token);
+  });
+
+  test('test getUserInfo', async () => {
+    const notebookListStubResponse = { username: 'user', id: 'id' };
+    const inputStub = {
+      access_token: 'access_token',
+      refresh_token: 'refresh_token',
+      client_id: 'client_id',
+      client_secret: 'client_secret',
+      wallabag_host: 'https://wallabag_host',
+    };
+    const mockRequestService = new MockRequestService(() => notebookListStubResponse);
+    const client = new WallabagClient(inputStub, mockRequestService);
+    const result = await client.getUserInfo();
+    const expectUrlGenerated = `${inputStub.wallabag_host}/api/user.json`;
+    expect(mockRequestService.mock.request.mock.calls[0][0]).toEqual(expectUrlGenerated);
+    expect(notebookListStubResponse).toEqual(result);
+  });
+
+  test('test getUserInfo with exceeded access_token', async () => {
+    const notebookListStubResponse = {
+      error: 'invalid_grant',
+      error_description: 'The access token provided has expired.',
+    };
+    const refreshTokenStubResponse = {
+      access_token: 'new_access_token',
+      refresh_token: 'new_refresh_token',
+    };
+
+    const inputStub = {
+      access_token: 'old_access_token',
+      refresh_token: 'refresh_token',
+      client_id: 'client_id',
+      client_secret: 'client_secret',
+      wallabag_host: 'https://wallabag_host',
+    };
+
+    const mockRequestService = new MockRequestService(url => {
+      switch (url) {
+        case `${inputStub.wallabag_host}/api/user.json`:
+          return notebookListStubResponse;
+        case `${inputStub.wallabag_host}/oauth/v2/token?grant_type=refresh_token&client_id=client_id&client_secret=client_secret&refresh_token=refresh_token`:
+          return refreshTokenStubResponse;
+        default:
+          throw Error(`No value for request to ${url}`);
+      }
+    });
+    const client = new WallabagClient(inputStub, mockRequestService);
+    const result = await client.getUserInfo();
+    const userInfoUrl = `${inputStub.wallabag_host}/api/user.json`;
+    let firstUserInfoRequest = mockRequestService.mock.request.mock.calls[0];
+    let secondUserInfoRequest = mockRequestService.mock.request.mock.calls[2];
+    expect(firstUserInfoRequest[0]).toEqual(userInfoUrl);
+    expect(secondUserInfoRequest[0]).toEqual(userInfoUrl);
+    expect(secondUserInfoRequest[1].headers.Authorization).toEqual(
+      `Bearer ${refreshTokenStubResponse}`
+    );
+
+    expect(notebookListStubResponse).toEqual(result);
+  });
+
+  test('test create document', async () => {
+    const createDocumentStubResponse = { username: 'user', id: 'id' };
+    const inputStub = {
+      access_token: 'access_token',
+      refresh_token: 'refresh_token',
+      client_id: 'client_id',
+      client_secret: 'client_secret',
+      wallabag_host: 'wallabag_host',
+    };
+    const mockRequestService = new MockRequestService(() => createDocumentStubResponse);
+    const client = new WallabagClient(inputStub, mockRequestService);
+    await client.createDocument({
+      title: 'some_title',
+      content: 'some_content',
+      repositoryId: 'some_repo',
+    });
+    const expectUrlGenerated = `${inputStub.wallabag_host}/api/entries.json`;
+    const calledUrl = mockRequestService.mock.request.mock.calls[0][0];
+    const callRequest = mockRequestService.mock.request.mock.calls[0][1];
+    expect(calledUrl).toEqual(expectUrlGenerated);
+    expect(Object.keys(callRequest.data).length).toBeGreaterThan(0);
+    expect(callRequest.data.constructor).toEqual(FormData);
+    expect(callRequest.requestType).toEqual('form');
+    expect(callRequest.method).toEqual('post');
+  });
+});

--- a/src/common/backend/clients/wallabag/client.ts
+++ b/src/common/backend/clients/wallabag/client.ts
@@ -1,0 +1,120 @@
+import { IExtendRequestHelper, IRequestService } from '@/service/common/request';
+import { CreateDocumentRequest } from '../../index';
+import { RequestHelper } from '@/service/request/common/request';
+import showdown from 'showdown';
+import {
+  WallabagBackendServiceConfig,
+  WallabagCreateDocumentResponse,
+  WallabagRefreshTokenResponse,
+  WallabagUserInfoResponse,
+} from './interface';
+import { stringify } from 'qs';
+
+const FormData = require('form-data');
+
+const converter = new showdown.Converter();
+/**
+ * Client for self hosted wallabag or wallabag.com
+ */
+export default class WallabagClient {
+  private config: WallabagBackendServiceConfig;
+  private request: IExtendRequestHelper;
+  private readonly requestService: IRequestService;
+
+  /**
+   * This class wrap a IExtendRequestHelper to perform HTTP request
+   */
+  constructor(
+    {
+      access_token,
+      refresh_token,
+      client_id,
+      client_secret,
+      wallabag_host,
+    }: WallabagBackendServiceConfig,
+    request: IRequestService
+  ) {
+    this.config = { access_token, refresh_token, client_id, client_secret, wallabag_host };
+
+    this.requestService = request;
+    this.request = new RequestHelper({
+      baseURL: `${this.config.wallabag_host}/api/`,
+      request: this.requestService,
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    });
+  }
+
+  /**
+   * Perform a GET in user api to get current user information
+   *
+   * @see documentation https://app.wallabag.it/api/doc#get--api-user.{_format}
+   */
+  getUserInfo = async () => {
+    let response = await this.request.get<WallabagUserInfoResponse>('user.json');
+    if ((response as any).error && (response as any).error === 'invalid_grant') {
+      await this.refreshToken();
+      response = await this.request.get<WallabagUserInfoResponse>('user.json');
+    }
+
+    return response;
+  };
+
+  /**
+   * @TODO: Support markdown
+   *
+   * Perform a POST with document request as formData to wallabag server to create a note
+   *
+   * @see documentation https://github.com/wallabag/wallabag/wiki/wallabag-api
+   */
+  createDocument = async (info: CreateDocumentRequest): Promise<WallabagCreateDocumentResponse> => {
+    const formData = new FormData();
+    const html = converter.makeHtml(`${info.content}`);
+    formData.append('content', html);
+    formData.append('title', info.title);
+    if (info.url) {
+      formData.append('url', info.url as string);
+    }
+
+    return this.request.postForm<WallabagCreateDocumentResponse>('entries.json', {
+      data: formData,
+    });
+  };
+
+  /**
+   * Perform a GET in token api
+   *
+   * @see documentation https://doc.wallabag.org/en/developer/api/oauth.html
+   */
+  refreshToken = async () => {
+    if (
+      this.config.client_secret === '' ||
+      this.config.client_id === '' ||
+      this.config.access_token === '' ||
+      this.config.refresh_token === ''
+    ) {
+      throw new Error('Cannot login');
+    }
+    const response = await this.request.get<WallabagRefreshTokenResponse>(
+      `${this.config.wallabag_host}/oauth/v2/token?${stringify({
+        grant_type: 'refresh_token',
+        client_id: this.config.client_id,
+        client_secret: this.config.client_secret,
+        refresh_token: this.config.refresh_token,
+      })}`
+    );
+    this.config.access_token = response.access_token;
+    this.config.refresh_token = response.refresh_token;
+
+    this.request = new RequestHelper({
+      baseURL: `${this.config.wallabag_host}/api/`,
+      request: this.requestService,
+      headers: {
+        Authorization: `Bearer ${response.access_token}`,
+      },
+    });
+
+    return response.access_token;
+  };
+}

--- a/src/common/backend/clients/wallabag/client.ts
+++ b/src/common/backend/clients/wallabag/client.ts
@@ -1,5 +1,5 @@
 import { IExtendRequestHelper, IRequestService } from '@/service/common/request';
-import { CreateDocumentRequest } from '../../index';
+import { CreateDocumentRequest, UnauthorizedError } from 'common/backend/services/interface';
 import { RequestHelper } from '@/service/request/common/request';
 import showdown from 'showdown';
 import {
@@ -35,7 +35,6 @@ export default class WallabagClient {
     request: IRequestService
   ) {
     this.config = { access_token, refresh_token, client_id, client_secret, wallabag_host };
-
     this.requestService = request;
     this.request = new RequestHelper({
       baseURL: `${this.config.wallabag_host}/api/`,
@@ -67,8 +66,7 @@ export default class WallabagClient {
       return await fn();
     } catch (err) {
       if (err.response && err.response.status === 401) {
-        await this.refreshToken();
-        return fn();
+        throw new UnauthorizedError('Unauthorized! Please login to wallabag');
       }
       throw err;
     }
@@ -128,6 +126,6 @@ export default class WallabagClient {
       },
     });
 
-    return response.access_token;
+    return { access_token: response.access_token, refresh_token: response.refresh_token };
   };
 }

--- a/src/common/backend/clients/wallabag/interface.ts
+++ b/src/common/backend/clients/wallabag/interface.ts
@@ -3,22 +3,19 @@ export interface WallabagBackendServiceConfig {
   refresh_token: string;
   client_id: string;
   client_secret: string;
-  origin: string;
+  wallabag_host: string;
 }
 
-export interface WallabagTokenResponse {
+export interface WallabagRefreshTokenResponse {
   access_token: string;
   refresh_token: string;
 }
 
 export interface WallabagUserInfoResponse {
   username: string;
+  id: string;
 }
+
 export interface WallabagCreateDocumentResponse {
   id: string;
-  _links: {
-    self: {
-      href: string;
-    };
-  };
 }

--- a/src/common/backend/services/leanote/service.ts
+++ b/src/common/backend/services/leanote/service.ts
@@ -44,7 +44,7 @@ export default class LeanoteDocumentService implements DocumentService {
    */
   getRepositories = async () => {
     let response = await this.client.getSyncNotebooks();
-    if ((response as any).Msg && (response as any).Msg === 'NOTLOGIN') {
+    if ((response as any).error && (response as any).error === 'invalid_grant') {
       await this.client.login();
       response = await this.client.getSyncNotebooks();
     }

--- a/src/common/backend/services/wallabag/form.tsx
+++ b/src/common/backend/services/wallabag/form.tsx
@@ -3,9 +3,9 @@ import '@ant-design/compatible/assets/index.less';
 import { Input } from 'antd';
 import { FormComponentProps } from '@ant-design/compatible/es/form';
 import React, { Fragment } from 'react';
-import { WallabagBackendServiceConfig } from './interface';
 import useOriginForm from '@/hooks/useOriginForm';
 import { FormattedMessage } from 'react-intl';
+import { WallabagBackendServiceConfig } from 'common/backend/clients/wallabag/interface';
 
 interface WallabagFormProps {
   verified?: boolean;
@@ -32,26 +32,24 @@ const FormItem: React.FC<WallabagFormProps & FormComponentProps> = props => {
   let editMode = info ? true : false;
   return (
     <Fragment>
-      <Form.Item label="Host">
-        {getFieldDecorator('origin', {
-          initialValue: initData.origin || 'https://app.wallabag.it',
-          rules: [
-            {
-              required: true,
-              message: 'Host is required!',
-            },
-            ...formRules,
-          ],
+      <Form.Item
+        label={
+          <FormattedMessage id="backend.services.confluence.form.origin" defaultMessage="Origin" />
+        }
+      >
+        {form.getFieldDecorator('wallabag_host', {
+          initialValue: info?.wallabag_host || 'https://app.wallabag.it',
+          rules: formRules,
         })(
           <Input.Search
             enterButton={
               <FormattedMessage
-                id="backend.services.wallabag.form.authentication"
+                id="backend.services.confluence.form.authentication"
                 defaultMessage="Authentication"
               />
             }
-            disabled={editMode || formVerified}
             onSearch={handleAuthentication}
+            disabled={verified}
           />
         )}
       </Form.Item>

--- a/src/common/backend/services/wallabag/form.tsx
+++ b/src/common/backend/services/wallabag/form.tsx
@@ -1,0 +1,106 @@
+import { Form } from '@ant-design/compatible';
+import '@ant-design/compatible/assets/index.less';
+import { Input } from 'antd';
+import { FormComponentProps } from '@ant-design/compatible/es/form';
+import React, { Fragment } from 'react';
+import { WallabagBackendServiceConfig } from './interface';
+import useOriginForm from '@/hooks/useOriginForm';
+import { FormattedMessage } from 'react-intl';
+
+interface WallabagFormProps {
+  verified?: boolean;
+  info?: WallabagBackendServiceConfig;
+}
+
+const FormItem: React.FC<WallabagFormProps & FormComponentProps> = props => {
+  const {
+    form,
+    form: { getFieldDecorator },
+    info,
+    verified,
+  } = props;
+
+  const { verified: formVerified, handleAuthentication, formRules } = useOriginForm({
+    form,
+    initStatus: !!info,
+  });
+
+  let initData: Partial<WallabagBackendServiceConfig> = {};
+  if (info) {
+    initData = info;
+  }
+  let editMode = info ? true : false;
+  return (
+    <Fragment>
+      <Form.Item label="Host">
+        {getFieldDecorator('origin', {
+          initialValue: initData.origin || 'https://app.wallabag.it',
+          rules: [
+            {
+              required: true,
+              message: 'Host is required!',
+            },
+            ...formRules,
+          ],
+        })(
+          <Input.Search
+            enterButton={
+              <FormattedMessage
+                id="backend.services.wallabag.form.authentication"
+                defaultMessage="Authentication"
+              />
+            }
+            disabled={editMode || formVerified}
+            onSearch={handleAuthentication}
+          />
+        )}
+      </Form.Item>
+      <Form.Item label="Access Token">
+        {getFieldDecorator('access_token', {
+          initialValue: initData.access_token,
+          rules: [
+            {
+              required: true,
+              message: 'Access Token is required!',
+            },
+          ],
+        })(<Input disabled={editMode || verified || !formVerified} />)}
+      </Form.Item>
+      <Form.Item label="Refresh Token">
+        {getFieldDecorator('refresh_token', {
+          initialValue: initData.refresh_token,
+          rules: [
+            {
+              required: true,
+              message: 'Refresh Token is required!',
+            },
+          ],
+        })(<Input disabled={editMode || verified || !formVerified} />)}
+      </Form.Item>
+      <Form.Item label="Client Id">
+        {getFieldDecorator('client_id', {
+          initialValue: initData.client_id,
+          rules: [
+            {
+              required: true,
+              message: 'Client Id is required!',
+            },
+          ],
+        })(<Input disabled={editMode || verified || !formVerified} />)}
+      </Form.Item>
+      <Form.Item label="Client Secret">
+        {getFieldDecorator('client_secret', {
+          initialValue: initData.client_secret,
+          rules: [
+            {
+              required: true,
+              message: 'Client Secret is required!',
+            },
+          ],
+        })(<Input disabled={editMode || verified || !formVerified} />)}
+      </Form.Item>
+    </Fragment>
+  );
+};
+
+export default FormItem;

--- a/src/common/backend/services/wallabag/form.tsx
+++ b/src/common/backend/services/wallabag/form.tsx
@@ -23,6 +23,7 @@ const FormItem: React.FC<WallabagFormProps & FormComponentProps> = props => {
   const { verified: formVerified, handleAuthentication, formRules } = useOriginForm({
     form,
     initStatus: !!info,
+    originKey: 'wallabag_host',
   });
 
   let initData: Partial<WallabagBackendServiceConfig> = {};

--- a/src/common/backend/services/wallabag/index.ts
+++ b/src/common/backend/services/wallabag/index.ts
@@ -1,6 +1,6 @@
 import { ServiceMeta } from './../interface';
 import Service from './service';
-import Form from './form';
+import form from './form';
 
 export default (): ServiceMeta => {
   return {
@@ -8,7 +8,7 @@ export default (): ServiceMeta => {
     icon: 'wallabag',
     type: 'wallabag',
     service: Service,
-    form: Form,
+    form: form,
     homePage: 'https://www.wallabag.com/',
   };
 };

--- a/src/common/backend/services/wallabag/index.ts
+++ b/src/common/backend/services/wallabag/index.ts
@@ -1,0 +1,14 @@
+import { ServiceMeta } from './../interface';
+import Service from './service';
+import Form from './form';
+
+export default (): ServiceMeta => {
+  return {
+    name: 'Wallabag',
+    icon: 'wallabag',
+    type: 'wallabag',
+    service: Service,
+    form: Form,
+    homePage: 'https://www.wallabag.com/',
+  };
+};

--- a/src/common/backend/services/wallabag/interface.ts
+++ b/src/common/backend/services/wallabag/interface.ts
@@ -1,0 +1,24 @@
+export interface WallabagBackendServiceConfig {
+  access_token: string;
+  refresh_token: string;
+  client_id: string;
+  client_secret: string;
+  origin: string;
+}
+
+export interface WallabagTokenResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+export interface WallabagUserInfoResponse {
+  username: string;
+}
+export interface WallabagCreateDocumentResponse {
+  id: string;
+  _links: {
+    self: {
+      href: string;
+    };
+  };
+}

--- a/src/common/backend/services/wallabag/service.ts
+++ b/src/common/backend/services/wallabag/service.ts
@@ -1,4 +1,8 @@
-import { DocumentService, CreateDocumentRequest, UserInfo } from './../../index';
+import {
+  DocumentService,
+  CreateDocumentRequest,
+  UserInfo,
+} from '@/common/backend/services/interface';
 import md5 from '@web-clipper/shared/lib/md5';
 import { CompleteStatus } from '../interface';
 import WallabagClient from 'common/backend/clients/wallabag/client';
@@ -46,6 +50,15 @@ export default class WallabagDocumentService implements DocumentService {
     const document = await this.client.createDocument(info);
     return {
       href: `${this.config.wallabag_host}/view/${encodeURIComponent(document.id)}`,
+    };
+  };
+
+  refreshToken = async ({ access_token, refresh_token, ...rest }: WallabagBackendServiceConfig) => {
+    const tokens = await this.client.refreshToken();
+    return {
+      ...rest,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
     };
   };
 }

--- a/src/common/backend/services/wallabag/service.ts
+++ b/src/common/backend/services/wallabag/service.ts
@@ -1,0 +1,114 @@
+import { DocumentService, CreateDocumentRequest, UserInfo, UnauthorizedError } from './../../index';
+import md5 from '@web-clipper/shared/lib/md5';
+import {
+  WallabagBackendServiceConfig,
+  WallabagCreateDocumentResponse,
+  WallabagTokenResponse,
+  WallabagUserInfoResponse,
+} from './interface';
+import { CompleteStatus } from '../interface';
+import showdown from 'showdown';
+import axios, { AxiosInstance } from 'axios';
+import { stringify } from 'qs';
+
+const converter = new showdown.Converter();
+
+export default class WallabagDocumentService implements DocumentService {
+  private request: AxiosInstance;
+  private access_token: string;
+  private readonly origin: string;
+
+  constructor({ origin, access_token }: WallabagBackendServiceConfig) {
+    const realHost = origin || 'https://app.wallabag.it';
+    this.request = axios.create({
+      baseURL: `${realHost}/api/`,
+      headers: { Authorization: `Bearer ${access_token}` },
+      timeout: 100000,
+      transformResponse: [data => JSON.parse(data)],
+      withCredentials: true,
+    });
+
+    this.request.interceptors.response.use(
+      r => r,
+      error => {
+        if (error.response && error.response.status === 401) {
+          const ere = new UnauthorizedError();
+          return Promise.reject(ere);
+        }
+        return Promise.reject(error);
+      }
+    );
+    this.access_token = access_token;
+    this.origin = origin;
+  }
+
+  getId = () => md5(this.access_token);
+
+  getUserInfo = async (): Promise<UserInfo> => {
+    const response = await this.request.get<WallabagUserInfoResponse>('user.json');
+    return {
+      name: response.data.username,
+      avatar: '',
+    };
+  };
+
+  getRepositories = async () => {
+    let userInfo = await this.getUserInfo();
+    return [
+      {
+        id: 'wallabag',
+        name: `Wallabag for ${userInfo.name}`,
+        groupId: 'wallabag',
+        groupName: 'Wallabag',
+      },
+    ];
+  };
+
+  createDocument = async (
+    info: CreateDocumentRequest & {
+      channel: string;
+      status: number;
+    }
+  ): Promise<CompleteStatus> => {
+    let formData = new FormData();
+    const html = converter.makeHtml(`${info.content}`);
+    formData.append('content', html);
+    formData.append('title', info.title);
+    if (info.url) {
+      formData.append('url', info.url as string);
+    }
+
+    const response = await this.request.post<WallabagCreateDocumentResponse>(
+      'entries.json',
+      formData
+    );
+    return {
+      href: `${this.origin}/view/${encodeURIComponent(response.data.id)}`,
+    };
+  };
+
+  refreshToken = async ({
+    access_token,
+    refresh_token,
+    client_id,
+    client_secret,
+    ...rest
+  }: WallabagBackendServiceConfig) => {
+    const response = await this.request.get<WallabagTokenResponse>(
+      `${this.origin}/oauth/v2/token?${stringify({
+        grant_type: 'refresh_token',
+        client_id,
+        client_secret,
+        refresh_token,
+      })}`
+    );
+    this.access_token = response.data.access_token;
+    return {
+      ...rest,
+      access_token: response.data.access_token,
+      refresh_token: response.data.refresh_token,
+      client_id,
+      client_secret,
+    };
+  };
+}


### PR DESCRIPTION
This adds support for [wallabag](https://wallabag.it/). It should work with their hosted service as well as self-hosted, but I only tested their hosted service.

To use it you need a oAuth token as described in their [documentation](https://doc.wallabag.org/en/developer/api/oauth.html).

- [x] Test
- [ ] Refactoring
- [ ] Help Document