### PR TITLE
support tencent cos for imageHost

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "showdown": "^1.9.0",
     "tldjs": "^2.3.1",
     "typedi": "^0.8.0",
-    "umi-request": "^1.2.15"
+    "umi-request": "^1.2.15",
+    "cos-js-sdk-v5": "^1.2.21"
   },
   "devDependencies": {
     "@types/yargs": "^17.0.2",

--- a/src/common/backend/imageHosting/tencent/form.tsx
+++ b/src/common/backend/imageHosting/tencent/form.tsx
@@ -1,0 +1,88 @@
+import React, { Fragment } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { FormComponentProps } from '@ant-design/compatible/lib/form';
+import { Form } from '@ant-design/compatible';
+import { Input } from 'antd';
+
+import { TencentImageHostingOption } from './type';
+
+
+interface Props extends FormComponentProps {
+  info: TencentImageHostingOption;
+}
+
+export default ({ form: { getFieldDecorator }, info }: Props) => {
+  const initInfo: Partial<Props['info']> = info || {};
+  return (
+    <Fragment>
+      <Form.Item label="secretId">
+        {getFieldDecorator('secretId', {
+          initialValue: initInfo.secretId,
+          rules: [
+            {
+              required: true,
+            },
+          ],
+        })(<Input placeholder="please input secretId"></Input>)}
+      </Form.Item>
+      <Form.Item label="secretKey">
+        {getFieldDecorator('secretKey', {
+          initialValue: initInfo.secretKey,
+          rules: [
+            {
+              required: true,
+            },
+          ],
+        })(<Input placeholder="please input secretKey"></Input>)}
+      </Form.Item>
+      <Form.Item label="bucket">
+        {getFieldDecorator('bucket', {
+          initialValue: initInfo.bucket,
+          rules: [
+            {
+              required: true,
+            },
+          ],
+        })(<Input placeholder="please input bucket"></Input>)}
+      </Form.Item>
+      <Form.Item label="region">
+        {getFieldDecorator('region', {
+          initialValue: initInfo.region,
+          rules: [
+            {
+              required: true,
+            },
+          ],
+        })(<Input placeholder="please input region"></Input>)}
+      </Form.Item>
+      <Form.Item label="savePath">
+        {getFieldDecorator('savePath', {
+          initialValue: initInfo.savePath,
+          rules: [
+            {
+              required: false,
+            },
+          ],
+        })(<Input placeholder="please input savePath"></Input>)}
+      </Form.Item>
+      <Form.Item label="domain">
+        {getFieldDecorator('domain', {
+          initialValue: initInfo.domain,
+          rules: [
+            {
+              required: false,
+              message: (
+                <FormattedMessage
+                  id="hooks.useOriginForm.origin.message"
+                  defaultMessage={`Wrong format,Examples https://developer.mozilla.org`}
+                />
+              )
+            },
+          ],
+        })(<Input placeholder="please input domain"></Input>)}
+      </Form.Item>
+
+    </Fragment>
+  );
+};
+

--- a/src/common/backend/imageHosting/tencent/index.ts
+++ b/src/common/backend/imageHosting/tencent/index.ts
@@ -1,0 +1,13 @@
+import { ImageHostingServiceMeta } from '../interface';
+import Service from './service';
+import Form from './form';
+
+export default (): ImageHostingServiceMeta => {
+  return {
+    name: 'tencent',
+    icon: 'tencent',
+    type: 'tencent',
+    form: Form,
+    service: Service,
+  };
+};

--- a/src/common/backend/imageHosting/tencent/service.ts
+++ b/src/common/backend/imageHosting/tencent/service.ts
@@ -1,0 +1,78 @@
+import { generateUuid } from '@web-clipper/shared/lib/uuid';
+import { UploadImageRequest, ImageHostingService } from '../interface';
+import { TencentImageHostingOption } from './type';
+import { IBasicRequestService } from '@/service/common/request';
+import { BlobToBase64 } from 'common/blob';
+import { Container } from 'typedi';
+import { isUndefined } from 'lodash';
+
+const COS = require('cos-js-sdk-v5');
+export default class TencentImageHostingService implements ImageHostingService {
+  private config: TencentImageHostingOption;
+  private cosClient;
+
+  constructor(config: TencentImageHostingOption) {
+    this.config = config;
+    this.cosClient = new COS({
+      SecretId: this.config.secretId,
+      SecretKey: this.config.secretKey,
+    });
+  }
+
+  getId(): string {
+    return this.config.secretId;
+  }
+
+  uploadImage = async ({ data }: UploadImageRequest) => {
+    return this.uploadBase64(data);
+  };
+
+  uploadImageUrl = async (url: string) => {
+    let imageBlob: Blob = await Container.get(IBasicRequestService).download(url);
+    const imageBase64 = await BlobToBase64(imageBlob);
+    return this.uploadBase64(imageBase64);
+  };
+  private uploadBase64 = async (base64Data: string): Promise<string> => {
+    let dataURLtoBlob = function(dataurl: string) {
+      let arr = dataurl.split(',');
+      let mime = arr[0].match(/:(.*?);/)[1];
+      let bstr = atob(arr[1]);
+      let n = bstr.length;
+      let u8arr = new Uint8Array(n);
+      while (n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      return new Blob([u8arr], { type: mime });
+    };
+    if (isUndefined(this.config.savePath)) this.config.savePath = '';
+    if (this.config.savePath.startsWith('/')) this.config.savePath.substr(1);
+    if (!this.config.savePath.endsWith('/') && this.config.savePath.length > 0)
+      this.config.savePath += '/';
+    const fileName = this.generateFilename(base64Data);
+    const key = `${this.config.savePath}${fileName}`;
+    this.cosClient.putObject(
+      {
+        Bucket: this.config.bucket,
+        Region: this.config.region,
+        Key: key,
+        Body: dataURLtoBlob(base64Data),
+      },
+      function(err: any, data: any) {
+        if (err) {
+          console.log(err);
+          throw err;
+        }
+        console.log(data.Location);
+      }
+    );
+    if (isUndefined(this.config.domain) || this.config.domain === '') {
+      return `https://${this.config.bucket}.cos.${this.config.region}.myqcloud.com/${key}`;
+    }
+    return `${this.config.domain}/${key}`;
+  };
+  private generateFilename = (data: string): string => {
+    const matchedSuffix: any = data.match(/^data:image\/(.*);base64,/);
+    const suffix: string = matchedSuffix[1];
+    return `${generateUuid()}\.${suffix}`;
+  };
+}

--- a/src/common/backend/imageHosting/tencent/type.ts
+++ b/src/common/backend/imageHosting/tencent/type.ts
@@ -1,0 +1,8 @@
+export interface TencentImageHostingOption {
+  secretId: string;
+  secretKey: string;
+  bucket?: string;
+  region: string;
+  savePath?: string;
+  domain?: string;
+}


### PR DESCRIPTION
简单支持腾讯云COS作为图床。支持用户选择保存路径以及自定义加速域名。
待优化项
- [ ] 从腾讯云拉取region列表并提供下拉选项
- [ ] 从腾讯云拉取bucket列表并提供下拉选项

Simple support Tencent COS for ImageHost，support user choose savePath and domain.
feature
- [ ] fetch region list from Tencent and use selectItem instead of input
- [ ] fetch bucket list from Tencent and use selectItem instead of input