### PR TITLE
滴答清单保存为"笔记"而不是默认的"任务"

### DIFF
--- a/src/common/backend/services/ticktick/service.ts
+++ b/src/common/backend/services/ticktick/service.ts
@@ -137,6 +137,7 @@ export default class TickTickDocumentService implements DocumentService {
           priority: 0,
           progress: 0,
           assignee: null,
+          kind: "NOTE",
           sortOrder: -4611733297427382000,
           startDate: null,
           isFloating: false,


### PR DESCRIPTION
保存网页现在默认的是任务,而不是笔记,任务会进入待完成清单,增加kind: "NOTE"可以把类型指定为笔记