### PR TITLE
chore: remove console.log

### DIFF
--- a/src/main/contentScript.main.ts
+++ b/src/main/contentScript.main.ts
@@ -66,5 +66,3 @@ async function updateMenu() {
 
   workerService.initContextMenu();
 }
-
-console.log('111222');

--- a/src/service/preference/browser/preferenceService.ts
+++ b/src/service/preference/browser/preferenceService.ts
@@ -12,7 +12,6 @@ class PreferenceService implements IPreferenceService {
   };
 
   constructor(@Inject(ISyncStorageService) private syncStorageService: IStorageService) {
-    console.log('this.syncStorageService', this.syncStorageService);
     this.syncStorageService.onDidChangeStorage((e) => {
       if (e === 'iconColor') {
         this.userPreference.iconColor = this.getIconColor();


### PR DESCRIPTION
这防止了以下令人困惑的控制台日志，该日志在安装 web-clipper 的情况下每次加载页面都会出现。
<img width="693" alt="image" src="https://github.com/user-attachments/assets/309f4ff0-7f35-4b4d-abd7-6d1211fde039">
