### PR TITLE
fix: yuque new doc not display in TOC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ webclipper.zip
 
 .now
 release
+yuque_openapi_20240904_green.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ webclipper.zip
 
 .now
 release
-yuque_openapi_20240904_green.yaml

--- a/src/common/backend/services/interface.ts
+++ b/src/common/backend/services/interface.ts
@@ -67,12 +67,19 @@ export interface ServiceMeta {
   permission?: chrome.permissions.Permissions;
 }
 
+export interface UpdateTOCRequest {
+  repositoryId: string;
+  documentId: Int32Array;
+}
+
 export interface DocumentService<T = any> {
   getId(): string;
 
   getRepositories(): Promise<Repository[]>;
 
   createDocument(request: CreateDocumentRequest): Promise<CompleteStatus | void>;
+
+	updateTOC(request: UpdateTOCRequest): Promise<T | void>;
 
   getUserInfo(): Promise<UserInfo>;
 

--- a/src/common/backend/services/interface.ts
+++ b/src/common/backend/services/interface.ts
@@ -67,19 +67,14 @@ export interface ServiceMeta {
   permission?: chrome.permissions.Permissions;
 }
 
-export interface UpdateTOCRequest {
-  repositoryId: string;
-  documentId: Int32Array;
-}
+export interface UpdateTOCRequest {}
 
 export interface DocumentService<T = any> {
   getId(): string;
 
   getRepositories(): Promise<Repository[]>;
 
-  createDocument(request: CreateDocumentRequest): Promise<CompleteStatus | void>;
-
-	updateTOC(request: UpdateTOCRequest): Promise<T | void>;
+  createDocument(request: T): Promise<CompleteStatus | void>;
 
   getUserInfo(): Promise<UserInfo>;
 

--- a/src/common/backend/services/yuque/interface.ts
+++ b/src/common/backend/services/yuque/interface.ts
@@ -1,4 +1,4 @@
-import { CompleteStatus, CreateDocumentRequest } from './../interface';
+import { CompleteStatus, CreateDocumentRequest, UpdateTOCRequest } from './../interface';
 import { Repository } from '../interface';
 
 export enum RepositoryType {
@@ -52,4 +52,9 @@ export interface YuqueCompleteStatus extends CompleteStatus {
 
 export interface YuqueCreateDocumentRequest extends CreateDocumentRequest {
   slug?: string;
+}
+
+export interface YuqueUpdateTOCRequest extends UpdateTOCRequest{
+  repositoryId: string;
+  documentId: number[];
 }

--- a/src/common/backend/services/yuque/service.ts
+++ b/src/common/backend/services/yuque/service.ts
@@ -15,6 +15,7 @@ import {
   YuqueRepository,
   YuqueCompleteStatus,
   YuqueCreateDocumentRequest,
+  UpdateTOCRequest,
 } from './interface';
 
 const HOST = 'https://www.yuque.com';
@@ -100,6 +101,9 @@ export default class YuqueDocumentService implements DocumentService {
       }
     );
     const data = response;
+
+    await this.updateTOC({ repositoryId, documentId: data.id.toString() });
+
     return {
       href: `${HOST}/${repository.namespace}/${data.slug}`,
       repositoryId,
@@ -149,5 +153,20 @@ export default class YuqueDocumentService implements DocumentService {
     } catch (_error) {
       return [];
     }
+  };
+
+  private updateTOC = async (request: UpdateTOCRequest) => {
+    const { repositoryId, documentId } = request;
+    const requestBody = {
+      action: 'prependNode',
+      action_mode: 'sibling',
+      node_uuid: repositoryId,
+      doc_ids: [documentId],
+      type: 'DOC',
+    };
+
+    await this.request.put<YuqueRepositoryResponse[]>(`repos/${repositoryId}/toc`, {
+      data: requestBody,
+    });
   };
 }

--- a/src/common/backend/services/yuque/service.ts
+++ b/src/common/backend/services/yuque/service.ts
@@ -15,7 +15,7 @@ import {
   YuqueRepository,
   YuqueCompleteStatus,
   YuqueCreateDocumentRequest,
-  UpdateTOCRequest,
+  YuqueUpdateTOCRequest,
 } from './interface';
 
 const HOST = 'https://www.yuque.com';
@@ -102,7 +102,7 @@ export default class YuqueDocumentService implements DocumentService {
     );
     const data = response;
 
-    await this.updateTOC({ repositoryId, documentId: data.id.toString() });
+    await this.updateYuqueTOC({ repositoryId, documentId: [data.id] });
 
     return {
       href: `${HOST}/${repository.namespace}/${data.slug}`,
@@ -155,18 +155,23 @@ export default class YuqueDocumentService implements DocumentService {
     }
   };
 
-  private updateTOC = async (request: UpdateTOCRequest) => {
-    const { repositoryId, documentId } = request;
+  private updateYuqueTOC = async (info: YuqueUpdateTOCRequest) => {
+    const { repositoryId, documentId } = info;
     const requestBody = {
       action: 'prependNode',
-      action_mode: 'sibling',
-      node_uuid: repositoryId,
-      doc_ids: [documentId],
+      action_mode: 'child',
+      doc_ids: documentId,
       type: 'DOC',
     };
 
-    await this.request.put<YuqueRepositoryResponse[]>(`repos/${repositoryId}/toc`, {
-      data: requestBody,
-    });
+    try {
+      const response = await this.request.put(`repos/${repositoryId}/toc`, {
+        data: requestBody,
+			});
+      return response;
+    } catch (_error) {
+      return {};
+    }
+
   };
 }


### PR DESCRIPTION
#1251 问题修复
根据官方文档，添加了个人版语雀更新目录的接口
可将新增到语雀中的文档显示在知识库目录中
在添加文档时，先调用原有的创建文档接口，然后调用新增的更新目录的接口