### PR TITLE
feat: support memos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 tmp/
 .DS_Store
 .idea
+.vscode
 yarn-error.log
 dll/
 webclipper.zip

--- a/src/common/backend/services/memos/form.tsx
+++ b/src/common/backend/services/memos/form.tsx
@@ -1,0 +1,73 @@
+import { Form } from '@ant-design/compatible';
+import '@ant-design/compatible/assets/index.less';
+import { Input } from 'antd';
+import { FormComponentProps } from '@ant-design/compatible/es/form';
+import React, { Fragment } from 'react';
+import { BaklibBackendServiceConfig } from './interface';
+import useOriginForm from '@/hooks/useOriginForm';
+import { FormattedMessage } from 'react-intl';
+
+interface BaklibFormProps {
+  verified?: boolean;
+  info?: BaklibBackendServiceConfig;
+}
+
+const FormItem: React.FC<BaklibFormProps & FormComponentProps> = props => {
+  const {
+    form,
+    form: { getFieldDecorator },
+    info,
+    verified,
+  } = props;
+
+  const { verified: formVerified, handleAuthentication, formRules } = useOriginForm({
+    form,
+    initStatus: !!info,
+  });
+
+  let initData: Partial<BaklibBackendServiceConfig> = {};
+  if (info) {
+    initData = info;
+  }
+  let editMode = info ? true : false;
+  return (
+    <Fragment>
+      <Form.Item label="Host">
+        {getFieldDecorator('origin', {
+          initialValue: initData.origin || 'https://www.baklib.com',
+          rules: [
+            {
+              required: true,
+              message: 'Host is required!',
+            },
+            ...formRules,
+          ],
+        })(
+          <Input.Search
+            enterButton={
+              <FormattedMessage
+                id="backend.services.baklib.form.authentication"
+                defaultMessage="Authentication"
+              />
+            }
+            disabled={editMode || formVerified}
+            onSearch={handleAuthentication}
+          />
+        )}
+      </Form.Item>
+      <Form.Item label="AccessToken">
+        {getFieldDecorator('accessToken', {
+          initialValue: initData.accessToken,
+          rules: [
+            {
+              required: true,
+              message: 'AccessToken is required!',
+            },
+          ],
+        })(<Input disabled={editMode || verified || !formVerified} />)}
+      </Form.Item>
+    </Fragment>
+  );
+};
+
+export default FormItem;

--- a/src/common/backend/services/memos/form.tsx
+++ b/src/common/backend/services/memos/form.tsx
@@ -3,16 +3,16 @@ import '@ant-design/compatible/assets/index.less';
 import { Input } from 'antd';
 import { FormComponentProps } from '@ant-design/compatible/es/form';
 import React, { Fragment } from 'react';
-import { BaklibBackendServiceConfig } from './interface';
+import { MemosBackendServiceConfig } from './interface';
 import useOriginForm from '@/hooks/useOriginForm';
 import { FormattedMessage } from 'react-intl';
 
-interface BaklibFormProps {
+interface MemosFormProps {
   verified?: boolean;
-  info?: BaklibBackendServiceConfig;
+  info?: MemosBackendServiceConfig;
 }
 
-const FormItem: React.FC<BaklibFormProps & FormComponentProps> = props => {
+const FormItem: React.FC<MemosFormProps & FormComponentProps> = props => {
   const {
     form,
     form: { getFieldDecorator },
@@ -25,7 +25,7 @@ const FormItem: React.FC<BaklibFormProps & FormComponentProps> = props => {
     initStatus: !!info,
   });
 
-  let initData: Partial<BaklibBackendServiceConfig> = {};
+  let initData: Partial<MemosBackendServiceConfig> = {};
   if (info) {
     initData = info;
   }
@@ -34,11 +34,17 @@ const FormItem: React.FC<BaklibFormProps & FormComponentProps> = props => {
     <Fragment>
       <Form.Item label="Host">
         {getFieldDecorator('origin', {
-          initialValue: initData.origin || 'https://www.baklib.com',
+          initialValue: initData.origin || 'https://demo.usememos.com',
           rules: [
             {
               required: true,
-              message: 'Host is required!',
+              message: (
+								<FormattedMessage
+                id="backend.services.memos.form.authentication"
+                defaultMessage="Host URL requeired!"
+              />
+							),
+							type: 'url',
             },
             ...formRules,
           ],
@@ -46,8 +52,8 @@ const FormItem: React.FC<BaklibFormProps & FormComponentProps> = props => {
           <Input.Search
             enterButton={
               <FormattedMessage
-                id="backend.services.baklib.form.authentication"
-                defaultMessage="Authentication"
+                id="backend.services.memos.form.hostTest"
+                defaultMessage="test"
               />
             }
             disabled={editMode || formVerified}
@@ -61,10 +67,16 @@ const FormItem: React.FC<BaklibFormProps & FormComponentProps> = props => {
           rules: [
             {
               required: true,
-              message: 'AccessToken is required!',
+              message: (
+								<FormattedMessage
+                id="backend.services.memos.accessToken.message"
+                defaultMessage='AccessToken is required!'
+              />),
             },
           ],
-        })(<Input disabled={editMode || verified || !formVerified} />)}
+        })(<Input
+					disabled={editMode || verified || !formVerified}
+					/>)}
       </Form.Item>
     </Fragment>
   );

--- a/src/common/backend/services/memos/headerForm.tsx
+++ b/src/common/backend/services/memos/headerForm.tsx
@@ -1,0 +1,66 @@
+import { Input, Tooltip, Select } from 'antd';
+import { Form } from '@ant-design/compatible';
+import '@ant-design/compatible/assets/index.less';
+import { FormComponentProps } from '@ant-design/compatible/lib/form';
+import React, { Fragment } from 'react';
+import locales from '@/common/locales';
+import { VisibilityType } from './interface';
+
+const { Option } = Select;
+
+const HeaderForm: React.FC<FormComponentProps> = ({ form: { getFieldDecorator } }) => {
+
+  return (
+    <Fragment>
+      <Form.Item>
+        <Tooltip
+          trigger={['focus']}
+          title={locales.format({
+            id: 'backend.services.memos.headerForm.tag',
+            defaultMessage: 'Input tags (eg. tag1, tag2...)'
+          })}
+          placement="topLeft"
+          overlayClassName="numeric-input"
+        >
+          {getFieldDecorator('tags', {
+            rules: [
+              {
+                pattern: /^(?! )[^\u4e00-\u9fa5~`!@#$%^&*()_+={}\[\]:;"'<>.?\/\\|]*[^\s.,;:!?"'()]*$/,
+                message: locales.format({
+                  id: 'backend.services.memos.headerForm.tag_error',
+                }),
+              },
+            ],
+          })(
+            <Input
+              autoComplete="off"
+              placeholder={locales.format({
+                id: 'backend.services.memos.headerForm.tag',
+                defaultMessage: 'Input tags (eg. tag1, tag2...)'
+              })}
+            />
+          )}
+        </Tooltip>
+      </Form.Item>
+
+      <Form.Item label={locales.format({
+              id: 'backend.services.memos.headerForm.visibility',
+              defaultMessage: 'visibility'
+					  })}>
+        {getFieldDecorator('visibility', {
+          initialValue: VisibilityType[0].value,
+        })(
+          <Select style={{ width: '100%' }}>
+            {VisibilityType.map(option => (
+              <Option key={option.value} value={option.value}>
+                {option.label()}
+              </Option>
+            ))}
+          </Select>
+        )}
+      </Form.Item>
+    </Fragment>
+  );
+};
+
+export default HeaderForm;

--- a/src/common/backend/services/memos/index.ts
+++ b/src/common/backend/services/memos/index.ts
@@ -2,15 +2,17 @@ import { ServiceMeta } from '../interface';
 import Service from './service';
 import Form from './form';
 import localeService from '@/common/locales';
+import headerForm from './headerForm';
 
 export default (): ServiceMeta => {
   return {
     name: localeService.format({
       id: 'backend.services.memos.name',
     }),
-    icon: 'memos',
+    icon: '',
     type: 'memos',
     service: Service,
+		headerForm: headerForm,
     form: Form,
     homePage: 'https://www.usememos.com/',
   };

--- a/src/common/backend/services/memos/index.ts
+++ b/src/common/backend/services/memos/index.ts
@@ -1,0 +1,17 @@
+import { ServiceMeta } from '../interface';
+import Service from './service';
+import Form from './form';
+import localeService from '@/common/locales';
+
+export default (): ServiceMeta => {
+  return {
+    name: localeService.format({
+      id: 'backend.services.memos.name',
+    }),
+    icon: 'memos',
+    type: 'memos',
+    service: Service,
+    form: Form,
+    homePage: 'https://www.usememos.com/',
+  };
+};

--- a/src/common/backend/services/memos/interface.ts
+++ b/src/common/backend/services/memos/interface.ts
@@ -1,0 +1,4 @@
+export interface MemosBackendServiceConfig {
+  accessToken: string;
+  origin: string;
+}

--- a/src/common/backend/services/memos/interface.ts
+++ b/src/common/backend/services/memos/interface.ts
@@ -1,4 +1,34 @@
+import { CreateDocumentRequest } from './../interface';
+import locales from '@/common/locales';
+
+export const VisibilityType = [
+  { label: () => locales.format({ id: 'backend.services.memos.headerForm.VisibilityType.private', defaultMessage: 'private' }), value: 'PRIVATE' },
+  { label: () => locales.format({ id: 'backend.services.memos.headerForm.VisibilityType.public', defaultMessage: 'public' }), value: 'PUBLIC' },
+] as const;
+
+export type VisibilityType = typeof VisibilityType[number];
+
 export interface MemosBackendServiceConfig {
   accessToken: string;
   origin: string;
+}
+
+export interface MemosUserResponse {
+  name: string;
+  username: string;
+  email: string;
+  avatarUrl: string;
+  description: string;
+}
+
+export interface MemosUserInfo {
+  name: string;
+  avatar: string;
+  homePage: string;
+  description: string;
+}
+
+export interface MemoCreateDocumentRequest extends CreateDocumentRequest {
+	visibility?: VisibilityType;
+	tags?: string;
 }

--- a/src/common/backend/services/memos/service.ts
+++ b/src/common/backend/services/memos/service.ts
@@ -1,0 +1,112 @@
+import { DocumentService, CreateDocumentRequest } from '../../index';
+import { extend, RequestMethod } from 'umi-request';
+import md5 from '@web-clipper/shared/lib/md5';
+import { MemosBackendServiceConfig } from './interface';
+import { CompleteStatus } from '../interface';
+import { Repository } from '@/common/backend/services/interface';
+
+interface MemosUserResponse {
+  name: string;
+  username: string;
+  email: string;
+  avatarUrl: string;
+  description: string;
+}
+
+interface UserInfo {
+  name: string;
+  avatar: string;
+  homePage: string;
+  description: string;
+}
+
+export default class MemosDocumentService implements DocumentService {
+  private request: RequestMethod;
+  private token: string;
+  private origin: string;
+	private userInfo: UserInfo | null;
+
+  constructor({ accessToken, origin }: MemosBackendServiceConfig) {
+    const realHost = origin || 'https://demo.usememos.com';
+    this.request = extend({
+      prefix: `${realHost}/api/`,
+      headers: { Authorization: `Bearer ${accessToken}` },
+      timeout: 5000,
+    });
+    this.request.interceptors.response.use(
+      async response => {
+        if (!response.ok) {
+          const json = await response.clone().json();
+          throw new Error(`(${response.status}) Err_id=${json.code || ''}: ${json.message || '未知错误'}`);
+        }
+        return response;
+      },
+      error => {
+        if (error.response) {
+          // 服务器返回错误
+          return error.response.json().then((json: any) => {
+            throw new Error(`(${error.response.status}) code=${json.id || ''}: ${json.message || error.message || '未知错误'}`);
+          });
+        }
+        // (50X)网络错误等
+        throw new Error(`(500): ${error.message || '网络错误'}`);
+      },
+    );
+    this.token = accessToken;
+    this.origin = realHost;
+    this.userInfo = null;
+  }
+
+  getId = () => {
+		return '0';
+	};
+
+  getUserInfo = async (): Promise<UserInfo> => {
+    const response = await this.request.post<MemosUserResponse>('v1/auth/status');
+
+    const userInfo: UserInfo = {
+      name: response.username || 'Memos User',
+      avatar: response.avatarUrl
+        ? `${this.origin}${response.avatarUrl}`
+        : 'https://demo.usememos.com/full-logo.webp',
+      homePage: this.origin,
+      description: response.description || 'Memos User',
+    };
+
+    this.userInfo = userInfo;
+    return userInfo;
+  };
+
+
+  createDocument = async (
+    info: CreateDocumentRequest
+  ): Promise<CompleteStatus> => {
+    if (!this.userInfo) {
+      this.userInfo = await this.getUserInfo();
+    }
+
+    const response = await this.request.post<{
+      id: string;
+      content: string;
+      creator: string;
+    }>('v1/memos', {
+      data: {
+        content: info.content,
+        visibility: 'PRIVATE',
+      },
+    });
+
+    return {
+      href: `${this.origin}/u/${this.userInfo.name}`,
+    };
+  };
+
+  getRepositories = async (): Promise<Repository[]> => {
+    return [{
+      id: 'memos_default',
+      name: '默认分区 Default Repo',
+      groupId: 'memos',
+      groupName: '默认分组 Defualt Group',
+    }];
+  };
+}

--- a/src/common/locales/data/zh-CN.json
+++ b/src/common/locales/data/zh-CN.json
@@ -25,6 +25,18 @@
   "backend.imageHosting.wiznote.name": "为知笔记",
   "backend.imageHosting.wiznote.builtInRemark": "为知笔记内置图床",
   "backend.not.unavailable": "暂时无法剪辑此类型的页面。\n\n刷新页面可以解决。",
+
+  "backend.services.memos.name": "Memos",
+	"backend.services.memos.form.hostTest": "检验",
+  "backend.services.memos.accessToken.message": "请输入 AccessToken",
+  "backend.services.memos.form.authentication": "请输入服务器地址",
+	"backend.services.memos.headerForm.tag": "请输入标签名称，多个标签用英文逗号分隔，如 tag1,tag2...",
+	"backend.services.memos.headerForm.visibility": "文档类型",
+	"backend.services.memos.headerForm.VisibilityType.private": "私人",
+	"backend.services.memos.headerForm.VisibilityType.public": "公开",
+	"backend.services.memos.headerForm.tag_error": "标签格式错误，请检查",
+
+	"backend.services.baklib.form.hostTest": "测试",
   "backend.services.baklib.form.authentication": "授权",
   "backend.services.baklib.headerForm.channel": "栏目",
   "backend.services.baklib.headerForm.description": "描述",


### PR DESCRIPTION
添加对 memos 的支持

1. 支持 memos 服务端认证，登录 memos 后台获取 authToken 方式认证（注意 Token 的有效期，若希望长久使用需要将 token 设置为永不失效）
![image](https://github.com/user-attachments/assets/eab808d9-2871-4ddd-b719-6242acea005f)

2. 支持 Memos 笔记中的以下配置
![image](https://github.com/user-attachments/assets/f738c965-6f6f-45ee-994d-299fcd062748)
   1. 可见类型设置（私人/公开）
   2. tag 设置，可设置多个 tag

---

问题

- [ ]  只支持 token 方式的验证，SSO 登录验证方式不支持
- [ ]  不支持以 Memos 作为图源
- [ ] Memos 自身接口限制：目前一篇笔记只能接收至多 8192 个字符
- [ ] 国际化语言支持：目前只支持简体中文和英语，其他语言字段可参考 zh-CN.json 中添加的内容进行适配